### PR TITLE
Add 'become' to install tasks, to ensure privileged user access

### DIFF
--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -2,17 +2,20 @@
 # tasks file for googlechrome | Debian/Ubuntu Family
 
 - name: Update repository cache and install gnupg2
+  become: true
   ansible.builtin.apt:
     name: gnupg2
     update_cache: true
   when: "ansible_os_family == 'Debian'"
 
 - name: Debian/Ubuntu Family | Add gpg signing key for {{ googlechrome_app_name }}
+  become: true
   ansible.builtin.apt_key:
     url: "{{ googlechrome_gpg_key }}"
     state: present
 
 - name: Debian/Ubuntu Family | Adding repository {{ googlechrome_repo_debian }}
+  become: true
   ansible.builtin.apt_repository:
     repo: "{{ googlechrome_repo_debian }}"
     state: "{{ googlechrome_repo_desired_state }}"
@@ -20,6 +23,7 @@
     update_cache: yes
 
 - name: Debian/Ubuntu Family | Installing {{ googlechrome_app_name }}
+  become: true
   ansible.builtin.apt:
     name: "{{ googlechrome_app_name }}"
     state: "{{ googlechrome_desired_state }}"

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -2,6 +2,7 @@
 # tasks file for googlechrome | EL Family
 
 - name: EL Family | Adding repository {{ googlechrome_repo_el }}
+  become: true
   ansible.builtin.yum_repository:
     name: "{{ googlechrome_repo_el_name }}"
     description: "{{ googlechrome_repo_el_description }}"
@@ -13,6 +14,7 @@
     enabled: "{{ googlechrome_repo_el_enabled }}"
 
 - name: EL Family | Installing {{ googlechrome_app_name }}
+  become: true
   ansible.builtin.yum:
     name: "{{ googlechrome_app_name }}"
     state: "{{ googlechrome_desired_state }}"


### PR DESCRIPTION
I would like to keep my ansible scripts executed as my non-privileged user, so I added the `become: true` properties.

I'm pretty new to Ansible, so feel free to correct me on a better solution if there is one.