### PR TITLE
Compatibility with systems that do not have apt-key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,8 @@
 # defaults file for googlechrome
 googlechrome_app_name: google-chrome-stable
 googlechrome_gpg_key: https://dl.google.com/linux/linux_signing_key.pub
-googlechrome_repo_debian: deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main
+googlechrome_gpg_key_checksum: sha256:0acccf28849439e3b2f7c60f899da45186a3a9b2fd02cc88cd44b25200016c56
+googlechrome_repo_debian: deb [arch=amd64 signed-by=/usr/share/keyrings/google.asc] https://dl.google.com/linux/chrome/deb/ stable main
 googlechrome_repo_debian_filename: google-chrome
 googlechrome_repo_el_name: google-chrome
 googlechrome_repo_el_description: google-chrome

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Google Chrome stable version installation or uninstallation in Debian/EL based systems with amd64 architecture.
   company: none
   license: MIT
-  min_ansible_version: 2.4
+  min_ansible_version: "2.4"
 
   platforms:
     - name: Ubuntu
@@ -15,6 +15,8 @@ galaxy_info:
         - focal
     - name: Debian
       versions:
+        - trixie
+        - bookworm
         - bullseye
         - buster
 

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -8,9 +8,12 @@
   when: "ansible_os_family == 'Debian'"
 
 - name: Debian/Ubuntu Family | Add gpg signing key for {{ googlechrome_app_name }}
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: "{{ googlechrome_gpg_key }}"
-    state: present
+    checksum: "{{ googlechrome_gpg_key_checksum }}"
+    dest: /usr/share/keyrings/google.asc
+    mode: '644'
+  notify: Update apt cache to include the new repo
 
 - name: Debian/Ubuntu Family | Adding repository {{ googlechrome_repo_debian }}
   ansible.builtin.apt_repository:

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -13,7 +13,7 @@
     enabled: "{{ googlechrome_repo_el_enabled }}"
 
 - name: EL Family | Installing {{ googlechrome_app_name }}
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ googlechrome_app_name }}"
     state: "{{ googlechrome_desired_state }}"
     update_cache: yes


### PR DESCRIPTION
apt-key has been deprecated for years and has been removed in Debian 13. This patch makes the role work on Debian 13 while maintaining backward compatibility.

I also fixed the linter warnings/errors (seen when running `ansible-lint`)